### PR TITLE
Prevent link and formatting breaking

### DIFF
--- a/src/main/java/me/stuntguy3000/java/redditlivebot/handler/RedditHandler.java
+++ b/src/main/java/me/stuntguy3000/java/redditlivebot/handler/RedditHandler.java
@@ -198,11 +198,10 @@ public class RedditHandler {
     public void postLiveThreadUpdate(LiveThreadChildrenData data, String threadID) {
         String author = data.getAuthor();
         String body = data.getBody();
-		body = body.replace("_", "\\_").replace("*", "\\*").replace("[", "\\[").replace("]", "\\]");
-		body = body.replace("(", "\\(").replace(")", "\\)").replace("`", "\\`")
-		
+        body = body.replace("_", "\\_").replace("*", "\\*").replace("[", "\\[").replace("]", "\\]");
+        body = body.replace("(", "\\(").replace(")", "\\)").replace("`", "\\`");
+
         RedditLiveBot.instance.getSubscriptionHandler().forwardMessage(Lang.send(TelegramHook.getRedditLiveChat(),
                 Lang.LIVE_THREAD_UPDATE, threadID, author, body));
     }
 }
-    

--- a/src/main/java/me/stuntguy3000/java/redditlivebot/handler/RedditHandler.java
+++ b/src/main/java/me/stuntguy3000/java/redditlivebot/handler/RedditHandler.java
@@ -198,6 +198,9 @@ public class RedditHandler {
     public void postLiveThreadUpdate(LiveThreadChildrenData data, String threadID) {
         String author = data.getAuthor();
         String body = data.getBody();
+		body = body.replace("_", "\_").replace("*", "\*").replace("[", "\[").replace("]", "\]");
+		body = body.replace("(", "\(").replace(")", "\)").replace("`", "\`")
+		
         RedditLiveBot.instance.getSubscriptionHandler().forwardMessage(Lang.send(TelegramHook.getRedditLiveChat(),
                 Lang.LIVE_THREAD_UPDATE, threadID, author, body));
     }

--- a/src/main/java/me/stuntguy3000/java/redditlivebot/handler/RedditHandler.java
+++ b/src/main/java/me/stuntguy3000/java/redditlivebot/handler/RedditHandler.java
@@ -198,8 +198,8 @@ public class RedditHandler {
     public void postLiveThreadUpdate(LiveThreadChildrenData data, String threadID) {
         String author = data.getAuthor();
         String body = data.getBody();
-		body = body.replace("_", "\_").replace("*", "\*").replace("[", "\[").replace("]", "\]");
-		body = body.replace("(", "\(").replace(")", "\)").replace("`", "\`")
+		body = body.replace("_", "\\_").replace("*", "\\*").replace("[", "\\[").replace("]", "\\]");
+		body = body.replace("(", "\\(").replace(")", "\\)").replace("`", "\\`")
 		
         RedditLiveBot.instance.getSubscriptionHandler().forwardMessage(Lang.send(TelegramHook.getRedditLiveChat(),
                 Lang.LIVE_THREAD_UPDATE, threadID, author, body));


### PR DESCRIPTION
This piece of code replaces Telegram markdown parser special chars with escaped ones on the post body.

I found no other method to place the replacing code since the message is built with the template on that method, and I can't really replace ALL occurences of the special chars, but only on the post body. Since all posts are parsed via Markdown, it shouldn't be much of an issue.
